### PR TITLE
#150 add return value for Mapdl.et() (#151)

### DIFF
--- a/pyansys/element_commands.py
+++ b/pyansys/element_commands.py
@@ -1,0 +1,18 @@
+import re
+
+
+def parse_et(msg):
+    """
+    Parse local element type number definition message
+    and return element type number
+    """
+    res = re.search(r"(ELEMENT TYPE\s*)([0-9]+)", msg)
+    if res is not None:
+        result = int(res.group(2))
+    else:
+        result = None
+    return result
+
+
+element_commands = {'ET': parse_et,
+}

--- a/pyansys/mapdl.py
+++ b/pyansys/mapdl.py
@@ -29,6 +29,7 @@ import psutil
 
 import pyansys
 from pyansys.geometry_commands import geometry_commands
+from pyansys.element_commands import element_commands
 from pyansys.mapdl_functions import _MapdlCommands
 from pyansys.deprec_commands import _DeprecCommands
 from pyansys.convert import is_float
@@ -656,6 +657,9 @@ class Mapdl(_MapdlCommands, _DeprecCommands):
 
         if short_cmd in geometry_commands:
             return geometry_commands[short_cmd](self.response)
+
+        if short_cmd in element_commands:
+            return element_commands[short_cmd](self.response)
 
         return self.response
 

--- a/tests/test_build_element.py
+++ b/tests/test_build_element.py
@@ -1,0 +1,19 @@
+import pytest
+import pyansys
+
+if pyansys.has_ansys:
+    mapdl = pyansys.Mapdl(override=True)
+    mapdl.prep7()
+
+
+@pytest.mark.skipif(not pyansys.has_ansys, reason="Requires ANSYS installed")
+def test_et():
+    mapdl.finish()
+    mapdl.clear()
+    mapdl.prep7()
+    n_plane183 = mapdl.et("", "PLANE183")
+    assert n_plane183 == 1
+    n_compare = int(mapdl.get_float("ETYP", 0, "NUM", "MAX"))
+    assert n_plane183 == n_compare
+    n_plane183 = mapdl.et(17, "PLANE183")
+    assert n_plane183 == 17


### PR DESCRIPTION
* #131 useful return values for Mapdl.k/l/a/al

* update fork to be similar to master

* #138 fix mapdl.al()
also fix return value for mapdl.k(1,0,0) (command is not available in parse_k)

* add return value to Mapdl.bsplin

* #146
add Mapdl.read_float_parameter
add Mapdl.read_float_from_inline_function

* #150 add return value for Mapdl.et()

* add tests for Mapdl.et()

* Revert "add tests for Mapdl.et()"

This reverts commit aa677bd3

* add tests for Mapdl.et()

* removed test_invalid()